### PR TITLE
Add R's air formatter

### DIFF
--- a/.github/workflows/air.yaml
+++ b/.github/workflows/air.yaml
@@ -1,0 +1,20 @@
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+name: air
+
+jobs:
+  run-air:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install air
+        uses: posit-dev/setup-air@v1
+
+      - name: Run air
+        shell: bash
+        run: air format . --check

--- a/.github/workflows/air.yaml
+++ b/.github/workflows/air.yaml
@@ -4,6 +4,8 @@ on:
     branches: [main, master]
 
 name: air
+permissions:
+  contents: read
 
 jobs:
   run-air:

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,9 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "lf"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true
+skip = []

--- a/air.toml
+++ b/air.toml
@@ -6,4 +6,4 @@ line-ending = "lf"
 persistent-line-breaks = true
 exclude = []
 default-exclude = true
-skip = []
+skip = ["tribble", "case_match", "case_when"]

--- a/projects/0000_00_proj_template/example.qmd
+++ b/projects/0000_00_proj_template/example.qmd
@@ -1,7 +1,6 @@
 ---
 title: "Project template"
-format:
-  html:
+format: html
 jupyter: python3
 ---
 

--- a/projects/2025_04_delivery_costs/analysis.qmd
+++ b/projects/2025_04_delivery_costs/analysis.qmd
@@ -112,28 +112,44 @@ rates_fil_df <- rates_df %>%
   ) %>%
   filter(
     # These are actually mis/unlabeled ASCs, psych hospitals, and cancer centers
-    !provider_id %in% c(
-      "2354", "7951", "7985", "7986", "7991", "7992", "8052", "8080",
-      "8124", "8166", "8169", "8073", "8079", "8064", "8063", "7914"
-    )
+    !provider_id %in%
+      c(
+        "2354",
+        "7951",
+        "7985",
+        "7986",
+        "7991",
+        "7992",
+        "8052",
+        "8080",
+        "8124",
+        "8166",
+        "8169",
+        "8073",
+        "8079",
+        "8064",
+        "8063",
+        "7914"
+      )
   ) %>%
   # This billing code is different from the other DRGs (no different severity
   # levels) to we're going to drop it for now
   filter(billing_code != "768") %>%
   # Some "other" contract methodologies are actually Medicare and Medicaid rates
-  filter(!coalesce(
-    final_rate_type == "other" & (
-      str_detect(
-        tolower(additional_payer_notes),
-        "medicare|medicaid|tricare"
-      ) |
-        str_detect(
-          tolower(additional_generic_notes),
+  filter(
+    !coalesce(
+      final_rate_type == "other" &
+        (str_detect(
+          tolower(additional_payer_notes),
           "medicare|medicaid|tricare"
-        )
-    ),
-    FALSE
-  ))
+        ) |
+          str_detect(
+            tolower(additional_generic_notes),
+            "medicare|medicaid|tricare"
+          )),
+      FALSE
+    )
+  )
 
 # Collapse plans to the provider-payer-drg level, prioritizing PPO + HMO rates,
 # then PPO only, then HMO only, then any other plan types (we want the highest
@@ -149,10 +165,20 @@ provider_payer_df <- rates_fil_df %>%
       # These variables don't vary within group, so it's fine to just take the
       # first value in order to preserve them when summarising
       c(
-        provider_name, provider_npi, parent_payer_name,
-        medicare_rate, hospital_type, total_beds, star_rating, lon, lat,
-        state_market_share, cbsa_name, starts_with("geoid_"),
-        starts_with("total_"), starts_with("median_hh_"),
+        provider_name,
+        provider_npi,
+        parent_payer_name,
+        medicare_rate,
+        hospital_type,
+        total_beds,
+        star_rating,
+        lon,
+        lat,
+        state_market_share,
+        cbsa_name,
+        starts_with("geoid_"),
+        starts_with("total_"),
+        starts_with("median_hh_"),
         starts_with("pct_ins_")
       ),
       first
@@ -195,28 +221,38 @@ provider_payer_df <- rates_fil_df %>%
 providers_df <- provider_payer_df %>%
   group_by(provider_id, billing_code) %>%
   summarize(
-    across(-all_of(c(
-      "payer_id", "parent_payer_name",
-      "agg_rate_provider_payer_type",
-      "agg_rate_provider_payer_count"
-    )), first),
+    across(
+      -all_of(c(
+        "payer_id",
+        "parent_payer_name",
+        "agg_rate_provider_payer_type",
+        "agg_rate_provider_payer_count"
+      )),
+      first
+    ),
     agg_rate_provider_med = wtd.quantile(
-      agg_rate_provider_payer_med, state_market_share, 0.5
+      agg_rate_provider_payer_med,
+      state_market_share,
+      0.5
     ),
     agg_rate_provider_count = sum(agg_rate_provider_payer_count)
   ) %>%
   mutate(
     # Order codes by their severity and delivery type
-    severity_label = factor(case_when(
+    severity_label = factor(
+      case_when(
       billing_code %in% c("783", "786", "796", "805") ~ "w/ MCC",
       billing_code %in% c("784", "787", "797", "806") ~ "w/ CC",
       billing_code %in% c("785", "788", "798", "807") ~ "no CC/MCC"
-    ), levels = c(
-      "w/ MCC",
-      "w/ CC",
-      "no CC/MCC"
-    )),
-    billing_code_label = factor(case_when(
+    ),
+      levels = c(
+        "w/ MCC",
+        "w/ CC",
+        "no CC/MCC"
+      )
+    ),
+    billing_code_label = factor(
+      case_when(
       billing_code %in% c("783", "784", "785") ~
         "C-Section<br>w/ Steril.",
       billing_code %in% c("786", "787", "788") ~
@@ -225,12 +261,14 @@ providers_df <- provider_payer_df %>%
         "Vaginal Deliv.<br>w/ Steril./D&C",
       billing_code %in% c("805", "806", "807") ~
         "Vaginal Deliv.<br>no Steril./D&C"
-    ), levels = c(
-      "Vaginal Deliv.<br>no Steril./D&C",
-      "Vaginal Deliv.<br>w/ Steril./D&C",
-      "C-Section<br>no Steril.",
-      "C-Section<br>w/ Steril."
-    ))
+    ),
+      levels = c(
+        "Vaginal Deliv.<br>no Steril./D&C",
+        "Vaginal Deliv.<br>w/ Steril./D&C",
+        "C-Section<br>no Steril.",
+        "C-Section<br>w/ Steril."
+      )
+    )
   ) %>%
   ungroup()
 
@@ -294,8 +332,11 @@ states_hexbin_gdf %>%
       med_rate,
       breaks = c(0, 7000, 10000, 13000, 16000, Inf),
       labels = c(
-        "< $7K", "$7-10K", "$10-13K",
-        "$13-16K", "> $16K"
+        "< $7K",
+        "$7-10K",
+        "$10-13K",
+        "$13-16K",
+        "> $16K"
       )
     ),
     rate_label = fct_rev(rate_label),
@@ -324,8 +365,11 @@ states_hexbin_gdf %>%
   ) +
   scale_color_manual(
     values = c(
-      "< $7K" = "grey40", "$7-10K" = "grey30", "$10-13K" = "grey10",
-      "$13-16K" = "grey95", "> $16K" = "grey95"
+      "< $7K" = "grey40",
+      "$7-10K" = "grey30",
+      "$10-13K" = "grey10",
+      "$13-16K" = "grey95",
+      "> $16K" = "grey95"
     ),
     na.value = "grey30"
   ) +
@@ -442,13 +486,18 @@ provider_cbsa_df <- providers_df %>%
   mutate(
     cbsa_label = fct_relabel(cbsa_name, \(x) {
       unique(paste0(
-        "**", x, "**<br>",
-        "<sup>Population: ", purrr::map_chr(
+        "**",
+        x,
+        "**<br>",
+        "<sup>Population: ",
+        purrr::map_chr(
           total_pop_cbsa,
           scales::label_number(scale_cut = cut_short_scale())
         ),
         " | ",
-        "Providers: ", n_distinct(provider_id), "</sup>"
+        "Providers: ",
+        n_distinct(provider_id),
+        "</sup>"
       ))
     }),
     billing_code_label = factor(
@@ -615,19 +664,21 @@ zcta_summ_df <- merge(
   by = "provider_id",
   all.x = TRUE,
   allow.cartesian = TRUE
-)[!is.na(agg_rate_provider_med), ][, .(
-  # Aggregate provider-level rates using a modified Huff model:
-  # https://en.wikipedia.org/wiki/Huff_model that replaces the power term
-  # with a (more accurate) logistic decay function
-  med_rate = sum(
-    agg_rate_provider_med * (
-      (total_beds * decay_function(duration_sec, nchs_code)) /
-        sum(total_beds * decay_function(duration_sec, nchs_code))
-    )
+)[!is.na(agg_rate_provider_med), ][,
+  .(
+    # Aggregate provider-level rates using a modified Huff model:
+    # https://en.wikipedia.org/wiki/Huff_model that replaces the power term
+    # with a (more accurate) logistic decay function
+    med_rate = sum(
+      agg_rate_provider_med *
+        ((total_beds * decay_function(duration_sec, nchs_code)) /
+          sum(total_beds * decay_function(duration_sec, nchs_code)))
+    ),
+    med_duration = median(duration_sec),
+    n = .N
   ),
-  med_duration = median(duration_sec),
-  n = .N
-), by = origin_id]
+  by = origin_id
+]
 
 # Plot all ZIP codes with the median rate of providers within 3 hours
 zcta_gdf %>%
@@ -637,8 +688,11 @@ zcta_gdf %>%
       med_rate,
       breaks = c(0, 7000, 10000, 13000, 16000, Inf),
       labels = c(
-        "< $7K", "$7-10K", "$10-13K",
-        "$13-16K", "> $16K"
+        "< $7K",
+        "$7-10K",
+        "$10-13K",
+        "$13-16K",
+        "> $16K"
       )
     ),
     rate_label = fct_rev(rate_label)
@@ -761,8 +815,11 @@ providers_df %>%
   mutate(
     nchs_code = fct_relabel(nchs_code, \(x) {
       unique(paste0(
-        "**", x, "**<br>",
-        "<sup>Providers: ", purrr::map_chr(
+        "**",
+        x,
+        "**<br>",
+        "<sup>Providers: ",
+        purrr::map_chr(
           count,
           scales::label_number(scale_cut = cut_short_scale())
         ),

--- a/projects/2025_05_bsca_hoag/analysis.qmd
+++ b/projects/2025_05_bsca_hoag/analysis.qmd
@@ -45,23 +45,27 @@ options(tigris_use_cache = TRUE)
 # Transform numbers into dollar amounts, but don't truncate small values e.g.
 # 100 becomes $100, 1000 becomes $1K, 1000000 becomes $1M, etc.
 label_dollar_short <- function(x) {
-  sapply(x, function(val) {
-    if (is.na(val)) {
-      return(NA_character_)
-    }
+  sapply(
+    x,
+    function(val) {
+      if (is.na(val)) {
+        return(NA_character_)
+      }
 
-    abs_val <- abs(val)
-    sign_str <- ifelse(val < 0, "-", "")
-    if (abs_val >= 1e9) {
-      paste0(sign_str, "$", round(abs_val / 1e9, 0), "B")
-    } else if (abs_val >= 1e6) {
-      paste0(sign_str, "$", round(abs_val / 1e6, 0), "M")
-    } else if (abs_val >= 1e3) {
-      paste0(sign_str, "$", round(abs_val / 1e3, 1), "K")
-    } else {
-      paste0(sign_str, "$", formatC(abs_val, format = "f", digits = 0))
-    }
-  }, USE.NAMES = FALSE)
+      abs_val <- abs(val)
+      sign_str <- ifelse(val < 0, "-", "")
+      if (abs_val >= 1e9) {
+        paste0(sign_str, "$", round(abs_val / 1e9, 0), "B")
+      } else if (abs_val >= 1e6) {
+        paste0(sign_str, "$", round(abs_val / 1e6, 0), "M")
+      } else if (abs_val >= 1e3) {
+        paste0(sign_str, "$", round(abs_val / 1e3, 1), "K")
+      } else {
+        paste0(sign_str, "$", formatC(abs_val, format = "f", digits = 0))
+      }
+    },
+    USE.NAMES = FALSE
+  )
 }
 ```
 
@@ -165,7 +169,8 @@ medicare_provider_df <- rates_df |>
     prov_fct = case_when(
       str_detect(provider_name, "Hoag") ~ "Hoag",
       provider_name == "University of California Irvine Medical Center" |
-        str_detect(provider_name, "UCI") ~ "UCI",
+        str_detect(provider_name, "UCI") ~
+        "UCI",
       str_detect(provider_name, "St Jude|St Joseph|Providence") ~ "Providence",
       .default = "Other"
     ),
@@ -184,15 +189,18 @@ medicare_provider_hist <- medicare_provider_df |>
   ggplot() +
   annotate(
     "segment",
-    x = 2.175, xend = 2.175,
-    y = -Inf, yend = 0.38,
+    x = 2.175,
+    xend = 2.175,
+    y = -Inf,
+    yend = 0.38,
     color = "green3",
     linewidth = 0.8,
     lty = "11"
   ) +
   annotate(
     "richtext",
-    x = 2.175, y = 0.38,
+    x = 2.175,
+    y = 0.38,
     vjust = 0,
     size = 3.5,
     fill = "transparent",
@@ -203,15 +211,18 @@ medicare_provider_hist <- medicare_provider_df |>
   ) +
   annotate(
     "segment",
-    x = 2.671, xend = 2.671,
-    y = -Inf, yend = 0.33,
+    x = 2.671,
+    xend = 2.671,
+    y = -Inf,
+    yend = 0.33,
     color = "#215fab",
     linewidth = 0.8,
     lty = "11"
   ) +
   annotate(
     "richtext",
-    x = 2.671, y = 0.33,
+    x = 2.671,
+    y = 0.33,
     vjust = 0,
     size = 3.5,
     fill = "transparent",
@@ -222,15 +233,18 @@ medicare_provider_hist <- medicare_provider_df |>
   ) +
   annotate(
     "segment",
-    x = 3.1275, xend = 3.1275,
-    y = -Inf, yend = 0.3,
+    x = 3.1275,
+    xend = 3.1275,
+    y = -Inf,
+    yend = 0.3,
     color = "#e59c35",
     linewidth = 0.8,
-    lty="11"
+    lty = "11"
   ) +
   annotate(
     "richtext",
-    x = 3.1275, y = 0.3,
+    x = 3.1275,
+    y = 0.3,
     vjust = 0,
     size = 3.5,
     fill = "transparent",
@@ -283,7 +297,8 @@ medicare_provider_df |>
   scale_color_manual(values = provider_colors) +
   annotate(
     "text",
-    y = 33.675, x = -118.37,
+    y = 33.675,
+    x = -118.37,
     label = "Each dot is\none hospital",
     size = 3,
     hjust = 1,
@@ -292,22 +307,27 @@ medicare_provider_df |>
   annotate(
     "curve",
     curvature = 0.1,
-    y = 33.7, x = -118.37,
-    yend = 33.8, xend = -118.344,
+    y = 33.7,
+    x = -118.37,
+    yend = 33.8,
+    xend = -118.344,
     arrow = arrow(length = unit(0.01, "npc")),
     color = "grey30"
   ) +
   annotate(
     "curve",
     curvature = -0.2,
-    y = 33.65, x = -118.37,
-    yend = 33.598, xend = -118.33,
+    y = 33.65,
+    x = -118.37,
+    yend = 33.598,
+    xend = -118.33,
     arrow = arrow(length = unit(0.01, "npc")),
     color = "grey30"
   ) +
   annotate(
     "text",
-    y = 33.475, x = -117.95,
+    y = 33.475,
+    x = -117.95,
     label = "Dotted lines are the median\nrate for each health system",
     size = 3,
     hjust = 0,
@@ -316,8 +336,10 @@ medicare_provider_df |>
   annotate(
     "curve",
     curvature = 0.2,
-    y = 33.495, x = -117.93,
-    yend = 33.545, xend = -118,
+    y = 33.495,
+    x = -117.93,
+    yend = 33.545,
+    xend = -118,
     arrow = arrow(length = unit(0.01, "npc")),
     color = "grey30"
   ) +
@@ -335,7 +357,8 @@ medicare_provider_df |>
       "high relative to Medicare"
     ),
     caption = paste0(
-      "Based on ", medicare_provider_df |>
+      "Based on ",
+      medicare_provider_df |>
         pull(num_rates) |>
         sum() |>
         scales::label_comma()(),
@@ -389,16 +412,24 @@ payer_comp_df <- rates_df |>
     med_rate_all = first(med_rate_all),
     num_providers = n(),
     .by = c(
-      "billing_code", "billing_code_type",
-      "proc_type", "payer_name", "payer_id"
+      "billing_code",
+      "billing_code_type",
+      "proc_type",
+      "payer_name",
+      "payer_id"
     )
   ) |>
   left_join(code_desc_df, by = "billing_code") |>
   left_join(payer_share_df, by = "payer_id") |>
   mutate(
     code = factor(paste0(
-      "**", code_desc, "**<br><sup>",
-      billing_code_type, " ", billing_code, "</sup>"
+      "**",
+      code_desc,
+      "**<br><sup>",
+      billing_code_type,
+      " ",
+      billing_code,
+      "</sup>"
     )),
     code = fct_rev(fct_reorder2(
       code,
@@ -421,13 +452,18 @@ payer_comp_df <- rates_df |>
     payer_name = case_match(
       payer_name,
       # nolint start
-      "Blue Shield of California" ~ "<span style='color:#4186d0'>Blue Shield<br>of California</span>",
+      "Blue Shield of California" ~
+        "<span style='color:#4186d0'>Blue Shield<br>of California</span>",
       "United Healthcare" ~ "United<br>Healthcare",
       .default = payer_name
       # nolint end
     ),
     payer_name = paste0(
-      "**", payer_name, "**<br>", payer_market_share, " market share"
+      "**",
+      payer_name,
+      "**<br>",
+      payer_market_share,
+      " market share"
     ),
     payer_name = ifelse(
       billing_code_type == "HCPCS",
@@ -487,7 +523,8 @@ payer_comp_df |>
   ) +
   scale_fill_manual(
     name = paste0(
-      "← Lowest price", paste0(rep(" ", 100), collapse = ""),
+      "← Lowest price",
+      paste0(rep(" ", 100), collapse = ""),
       "Highest price →\nPrice rank per procedure (row)"
     ),
     values = rev(RColorBrewer::brewer.pal(5, "BuPu"))
@@ -506,7 +543,8 @@ payer_comp_df |>
     y = "",
     x = "",
     caption = paste0(
-      "Based on ", payer_comp_df |>
+      "Based on ",
+      payer_comp_df |>
         pull(num_providers) |>
         sum() |>
         scales::label_comma()(),
@@ -608,17 +646,18 @@ payer_comp_df |>
 provider_comp_df <- rates_df |>
   filter(
     payer_name == "Blue Shield of California",
-    provider_name %in% c(
-      "Hoag Memorial Hospital",
-      "University of California Irvine Medical Center",
-      "Long Beach Memorial Medical Center",
-      "Orange Coast Memorial Medical Center",
-      "Saddleback Memorial Medical Center",
-      "St Joseph Hospital - Orange",
-      "St Jude Medical Center",
-      "Providence Mission Hospital - Mission Viejo",
-      "UCI Health Fountain Valley"
-    )
+    provider_name %in%
+      c(
+        "Hoag Memorial Hospital",
+        "University of California Irvine Medical Center",
+        "Long Beach Memorial Medical Center",
+        "Orange Coast Memorial Medical Center",
+        "Saddleback Memorial Medical Center",
+        "St Joseph Hospital - Orange",
+        "St Jude Medical Center",
+        "Providence Mission Hospital - Mission Viejo",
+        "UCI Health Fountain Valley"
+      )
   ) |>
   filter(
     # Keep only codes with rates for at least 6 providers and for Hoag
@@ -630,8 +669,13 @@ provider_comp_df <- rates_df |>
   left_join(code_desc_df, by = "billing_code") |>
   mutate(
     code = factor(paste0(
-      "**", code_desc, "**<br><sup>",
-      billing_code_type, " ", billing_code, "</sup>"
+      "**",
+      code_desc,
+      "**<br><sup>",
+      billing_code_type,
+      " ",
+      billing_code,
+      "</sup>"
     )),
     code = fct_rev(fct_reorder2(
       code,
@@ -718,7 +762,8 @@ provider_comp_df |>
   ) +
   scale_fill_manual(
     name = paste0(
-      "← Lowest price", paste0(rep(" ", 100), collapse = ""),
+      "← Lowest price",
+      paste0(rep(" ", 100), collapse = ""),
       "Highest price →\nPrice rank per procedure (row)"
     ),
     values = rev(RColorBrewer::brewer.pal(7, "BuPu")[c(rep(1, 2), 1:7)])
@@ -738,7 +783,8 @@ provider_comp_df |>
     y = "",
     x = "",
     caption = paste0(
-      "Based on ", nrow(provider_comp_df),
+      "Based on ",
+      nrow(provider_comp_df),
       " rates negotiated between providers and Blue Shield of California, ",
       "sourced from Turquoise Health<br>",
       "Stars represent CMS quality ratings for each hospital"

--- a/projects/2025_06_il_340b/analysis.qmd
+++ b/projects/2025_06_il_340b/analysis.qmd
@@ -157,13 +157,16 @@ drug_rates_imp_df <- drug_rates_imp_df |>
     rate_to_gross_imputed = is.na(rate_to_gross_avg_wtd) | gross_count_wtd < 20,
     rate_to_gross_avg_wtd = ifelse(
       rate_to_gross_imputed,
-      mean(drug_rates_imp_df$rate_to_gross_avg_wtd[
-        dplyr::between(
-          drug_rates_imp_df$total_beds,
-          total_beds * 0.5,
-          total_beds * 1.5
-        )
-      ], na.rm = TRUE),
+      mean(
+        drug_rates_imp_df$rate_to_gross_avg_wtd[
+          dplyr::between(
+            drug_rates_imp_df$total_beds,
+            total_beds * 0.5,
+            total_beds * 1.5
+          )
+        ],
+        na.rm = TRUE
+      ),
       rate_to_gross_avg_wtd
     )
   )
@@ -179,8 +182,11 @@ drug_profits_df <- il_hospitals_df |>
   inner_join(
     drug_rates_imp_df |>
       select(
-        provider_id, gross_poa_avg_wtd, contains("_count_"),
-        rate_to_gross_avg_wtd, rate_to_gross_imputed
+        provider_id,
+        gross_poa_avg_wtd,
+        contains("_count_"),
+        rate_to_gross_avg_wtd,
+        rate_to_gross_imputed
       ),
     by = c("provider_id")
   ) |>
@@ -198,19 +204,21 @@ drug_profits_df <- il_hospitals_df |>
     # hospitals general conversion rate * charged amount - cost. The upper bound
     # is the same but substituting the actual net-to-gross ratio from drug
     # price data
-    net_drug_profit_lower =
-      (mcr_drug_charged * mcr_conv_factor) - mcr_drug_cost,
-    net_drug_profit_upper =
-      (mcr_drug_charged * rate_to_gross_avg_wtd) - mcr_drug_cost,
+    net_drug_profit_lower = (mcr_drug_charged * mcr_conv_factor) -
+      mcr_drug_cost,
+    net_drug_profit_upper = (mcr_drug_charged * rate_to_gross_avg_wtd) -
+      mcr_drug_cost,
     # Calculate profits for only outpatient drugs. This is a good proxy for
     # 340B profits but isn't perfect since it doesn't factor in reduced costs,
     # % of patients who are 340B, contract pharmacy fees, etc.
-    net_outpatient_profit_lower =
-      (mcr_drug_charged * mcr_conv_factor * mcr_pct_outpatient) -
-        (mcr_drug_cost * mcr_pct_outpatient), # nolint
-    net_outpatient_profit_upper =
-      (mcr_drug_charged * rate_to_gross_avg_wtd * mcr_pct_outpatient) -
-        (mcr_drug_cost * mcr_pct_outpatient) # nolint
+    net_outpatient_profit_lower = (mcr_drug_charged *
+      mcr_conv_factor *
+      mcr_pct_outpatient) -
+      (mcr_drug_cost * mcr_pct_outpatient), # nolint
+    net_outpatient_profit_upper = (mcr_drug_charged *
+      rate_to_gross_avg_wtd *
+      mcr_pct_outpatient) -
+      (mcr_drug_cost * mcr_pct_outpatient) # nolint
   ) |>
   filter(
     !is.na(mcr_net_patient_revenue),
@@ -234,44 +242,56 @@ ggplot() +
   ) +
   annotate(
     "text",
-    x = 0.87, y = -13000,
+    x = 0.87,
+    y = -13000,
     label = "Hospital or clinic\nadministers drug",
     hjust = 1,
     lineheight = 0.9
   ) +
   annotate(
     "segment",
-    x = 0.9, xend = 1,
-    y = -13000, yend = -13000
+    x = 0.9,
+    xend = 1,
+    y = -13000,
+    yend = -13000
   ) +
   annotate(
     "segment",
-    x = 1, xend = 1,
-    y = -13000, yend = -11198,
+    x = 1,
+    xend = 1,
+    y = -13000,
+    yend = -11198,
     arrow = arrow(length = unit(0.2, "cm"), type = "closed")
   ) +
   annotate(
     "segment",
-    x = 0.5, xend = 1.5,
-    y = -11198, yend = -11198,
+    x = 0.5,
+    xend = 1.5,
+    y = -11198,
+    yend = -11198,
     linetype = "dashed"
   ) +
   annotate(
     "segment",
-    x = 1.5, xend = 2.5,
-    y = 18520 - 11198, yend = 18520 - 11198,
+    x = 1.5,
+    xend = 2.5,
+    y = 18520 - 11198,
+    yend = 18520 - 11198,
     linetype = "dashed"
   ) +
   annotate(
     "rect",
-    xmin = 0.2, xmax = 0.8,
-    ymin = -11198, ymax = 0,
+    xmin = 0.2,
+    xmax = 0.8,
+    ymin = -11198,
+    ymax = 0,
     fill = "#ec9993",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 0.5, y = -6000,
+    x = 0.5,
+    y = -6000,
     label = paste0(
       "**<span style='font-size:20px'>-$11,198</span>**<br><br>",
       "Provider buys<br>drug at ASP"
@@ -282,14 +302,17 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.2, xmax = 1.8,
-    ymin = -11198, ymax = 31328 - 11198,
+    xmin = 1.2,
+    xmax = 1.8,
+    ymin = -11198,
+    ymax = 31328 - 11198,
     fill = "#bee7f4",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = 15000,
+    x = 1.5,
+    y = 15000,
     label = paste0(
       "Hospital sets list<br>price",
       " at **$31,328<br>**<span style='font-size:12px'>",
@@ -301,13 +324,16 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.205, xmax = 1.795,
-    ymin = -11150, ymax = 18520 - 11198,
+    xmin = 1.205,
+    xmax = 1.795,
+    ymin = -11150,
+    ymax = 18520 - 11198,
     fill = "#7ccfe9"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = -2000,
+    x = 1.5,
+    y = -2000,
     label = paste0(
       "**<span style='font-size:20px'>+$18,520</span>**<br><br>",
       "Insurer/payer<br>reimburses at<br>negotiated rate"
@@ -318,14 +344,17 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 2.2, xmax = 2.8,
-    ymin = 0, ymax = 18520 - 11198,
+    xmin = 2.2,
+    xmax = 2.8,
+    ymin = 0,
+    ymax = 18520 - 11198,
     fill = "#91caab",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 2.5, y = 3600,
+    x = 2.5,
+    y = 3600,
     label = paste0(
       "**<span style='font-size:20px'>= $7,322</span>**<br><br>",
       "Hospital keeps<br>net cost recovery<br>(profit) from payer"
@@ -409,44 +438,56 @@ ggplot() +
   ) +
   annotate(
     "text",
-    x = 0.87, y = -11500,
+    x = 0.87,
+    y = -11500,
     label = "Hospital or clinic\nadministers drug",
     hjust = 1,
     lineheight = 0.9
   ) +
   annotate(
     "segment",
-    x = 0.9, xend = 1,
-    y = -11500, yend = -11500
+    x = 0.9,
+    xend = 1,
+    y = -11500,
+    yend = -11500
   ) +
   annotate(
     "segment",
-    x = 1, xend = 1,
-    y = -11500, yend = -8612,
+    x = 1,
+    xend = 1,
+    y = -11500,
+    yend = -8612,
     arrow = arrow(length = unit(0.2, "cm"), type = "closed")
   ) +
   annotate(
     "segment",
-    x = 0.5, xend = 1.5,
-    y = -8612, yend = -8612,
+    x = 0.5,
+    xend = 1.5,
+    y = -8612,
+    yend = -8612,
     linetype = "dashed"
   ) +
   annotate(
     "segment",
-    x = 1.5, xend = 2.205,
-    y = 18520 - 8612, yend = 18520 - 8612,
+    x = 1.5,
+    xend = 2.205,
+    y = 18520 - 8612,
+    yend = 18520 - 8612,
     linetype = "dashed"
   ) +
   annotate(
     "rect",
-    xmin = 0.2, xmax = 0.8,
-    ymin = -8612, ymax = 0,
+    xmin = 0.2,
+    xmax = 0.8,
+    ymin = -8612,
+    ymax = 0,
     fill = "#ec9993",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 0.5, y = -4500,
+    x = 0.5,
+    y = -4500,
     label = paste0(
       "**<span style='font-size:20px'>-$8,612</span>**<br><br>",
       "Provider buys<br>drug at 340B<br>discount price<sup>1</sup>"
@@ -457,14 +498,17 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.2, xmax = 1.8,
-    ymin = -8612, ymax = 31328 - 8612,
+    xmin = 1.2,
+    xmax = 1.8,
+    ymin = -8612,
+    ymax = 31328 - 8612,
     fill = "#bee7f4",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = 17000,
+    x = 1.5,
+    y = 17000,
     label = paste0(
       "Hospital sets list<br>price",
       " at **$31,328<br>**<span style='font-size:12px'>",
@@ -476,13 +520,16 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.205, xmax = 1.795,
-    ymin = -8550, ymax = 18520 - 8612,
+    xmin = 1.205,
+    xmax = 1.795,
+    ymin = -8550,
+    ymax = 18520 - 8612,
     fill = "#7ccfe9"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = 500,
+    x = 1.5,
+    y = 500,
     label = paste0(
       "**<span style='font-size:20px'>+$18,520</span>**<br><br>",
       "Insurer/payer<br>reimburses at<br>negotiated rate"
@@ -493,20 +540,25 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 2.2, xmax = 2.8,
-    ymin = 0, ymax = 18520 - 8612,
+    xmin = 2.2,
+    xmax = 2.8,
+    ymin = 0,
+    ymax = 18520 - 8612,
     fill = "#91caab",
     color = "black"
   ) +
   annotate(
     "rect",
-    xmin = 2.205, xmax = 2.795,
-    ymin = 18520 - 11198, ymax = 18520 - 8612 - 50,
+    xmin = 2.205,
+    xmax = 2.795,
+    ymin = 18520 - 11198,
+    ymax = 18520 - 8612 - 50,
     fill = "#428a62"
   ) +
   annotate(
     "richtext",
-    x = 2.5, y = 3700,
+    x = 2.5,
+    y = 3700,
     label = paste0(
       "**<span style='font-size:20px'>= $9,908</span>**<br>",
       "<br>Dark green is extra<br>profit from 340B<br>compared to ASP"
@@ -589,44 +641,56 @@ ggplot() +
   ) +
   annotate(
     "text",
-    x = 0.87, y = -11500,
+    x = 0.87,
+    y = -11500,
     label = "Hospital or clinic\nadministers drug",
     hjust = 1,
     lineheight = 0.9
   ) +
   annotate(
     "segment",
-    x = 0.9, xend = 1,
-    y = -11500, yend = -11500
+    x = 0.9,
+    xend = 1,
+    y = -11500,
+    yend = -11500
   ) +
   annotate(
     "segment",
-    x = 1, xend = 1,
-    y = -11500, yend = -8612,
+    x = 1,
+    xend = 1,
+    y = -11500,
+    yend = -8612,
     arrow = arrow(length = unit(0.2, "cm"), type = "closed")
   ) +
   annotate(
     "segment",
-    x = 0.5, xend = 1.5,
-    y = -8612, yend = -8612,
+    x = 0.5,
+    xend = 1.5,
+    y = -8612,
+    yend = -8612,
     linetype = "dashed"
   ) +
   annotate(
     "segment",
-    x = 1.5, xend = 2.205,
-    y = 11870 - 8612, yend = 11870 - 8612,
+    x = 1.5,
+    xend = 2.205,
+    y = 11870 - 8612,
+    yend = 11870 - 8612,
     linetype = "dashed"
   ) +
   annotate(
     "rect",
-    xmin = 0.2, xmax = 0.8,
-    ymin = -8612, ymax = 0,
+    xmin = 0.2,
+    xmax = 0.8,
+    ymin = -8612,
+    ymax = 0,
     fill = "#ec9993",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 0.5, y = -4500,
+    x = 0.5,
+    y = -4500,
     label = paste0(
       "**<span style='font-size:20px'>-$8,612</span>**<br><br>",
       "Provider buys<br>drug at 340B<br>discount price<sup>1</sup>"
@@ -637,14 +701,17 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.2, xmax = 1.8,
-    ymin = -8612, ymax = 31328 - 8612,
+    xmin = 1.2,
+    xmax = 1.8,
+    ymin = -8612,
+    ymax = 31328 - 8612,
     fill = "#bee7f4",
     color = "black"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = 17000,
+    x = 1.5,
+    y = 17000,
     label = paste0(
       "Hospital sets list<br>price",
       " at **$31,328<br>**<span style='font-size:12px'>",
@@ -656,13 +723,16 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 1.205, xmax = 1.795,
-    ymin = -8550, ymax = 11870 - 8612,
+    xmin = 1.205,
+    xmax = 1.795,
+    ymin = -8550,
+    ymax = 11870 - 8612,
     fill = "#7ccfe9"
   ) +
   annotate(
     "richtext",
-    x = 1.5, y = -2700,
+    x = 1.5,
+    y = -2700,
     label = paste0(
       "**<span style='font-size:20px'>+$11,870</span>**<br><br>",
       "Medicare<br>reimburses at<br>ASP + 6%"
@@ -673,20 +743,25 @@ ggplot() +
   ) +
   annotate(
     "rect",
-    xmin = 2.2, xmax = 2.8,
-    ymin = 0, ymax = 11870 - 8612,
+    xmin = 2.2,
+    xmax = 2.8,
+    ymin = 0,
+    ymax = 11870 - 8612,
     fill = "#91caab",
     color = "black"
   ) +
   annotate(
     "rect",
-    xmin = 2.205, xmax = 2.795,
-    ymin = 11870 - 11198, ymax = 11870 - 8612 - 50,
+    xmin = 2.205,
+    xmax = 2.795,
+    ymin = 11870 - 11198,
+    ymax = 11870 - 8612 - 50,
     fill = "#428a62"
   ) +
   annotate(
     "richtext",
-    x = 2.5, y = 4200,
+    x = 2.5,
+    y = 4200,
     label = paste0(
       "**<span style='font-size:20px'>= $3,258</span>**"
     ),
@@ -696,7 +771,8 @@ ggplot() +
   ) +
   annotate(
     "richtext",
-    x = 2.5, y = -3800,
+    x = 2.5,
+    y = -3800,
     label = paste0(
       "<br>Dark green is extra<br>profit from 340B<br>compared to ASP<br><br>",
       "(Original profit was $672)"
@@ -804,7 +880,8 @@ il_hospital_map_inset <- il_hospitals_df |>
   ) +
   annotate(
     "richtext",
-    x = -87.9, y = 41.4,
+    x = -87.9,
+    y = 41.4,
     label = "Inset area",
     size = 4,
     color = "darkred",
@@ -841,8 +918,10 @@ il_hospitals_df |>
   annotation_map_tile("cartolight", zoomin = 0) +
   annotate(
     "rect",
-    xmin = -Inf, xmax = Inf,
-    ymin = -Inf, ymax = Inf,
+    xmin = -Inf,
+    xmax = Inf,
+    ymin = -Inf,
+    ymax = Inf,
     fill = "white",
     alpha = 0.5
   ) +
@@ -856,9 +935,11 @@ il_hospitals_df |>
     values = entity_color_values,
     drop = FALSE
   ) +
-  guides(color = guide_legend(
-    override.aes = list(size = 6),
-  )) +
+  guides(
+    color = guide_legend(
+      override.aes = list(size = 6),
+    )
+  ) +
   labs(
     title = paste0(
       "Most 340B-qualified hospitals are in less ",
@@ -906,7 +987,10 @@ il_hospitals_df |>
   ) +
   inset_element(
     il_hospital_map_inset,
-    left = 0.0, right = 0.3, top = 1, bottom = -0.33
+    left = 0.0,
+    right = 0.3,
+    top = 1,
+    bottom = -0.33
   )
 ```
 
@@ -1146,8 +1230,10 @@ il_hospitals_npr_summ |>
   # Northwestern
   annotate(
     "rect",
-    xmin = 2.55975, xmax = 3.4425,
-    ymin = npr_rrc - npr_northwestern, ymax = npr_rrc,
+    xmin = 2.55975,
+    xmax = 3.4425,
+    ymin = npr_rrc - npr_northwestern,
+    ymax = npr_rrc,
     fill = "#506caf",
     linewidth = 1
   ) +
@@ -1161,15 +1247,18 @@ il_hospitals_npr_summ |>
       scales::dollar(npr_northwestern, accuracy = 0.01, scale = 1 / 1e9),
       "B)"
     ),
-    hjust = 0, vjust = 0.95,
+    hjust = 0,
+    vjust = 0.95,
     fill = "transparent",
     label.color = "transparent"
   ) +
   # UChicago
   annotate(
     "rect",
-    xmin = 0.55975, xmax = 1.4425,
-    ymin = npr_dsh - npr_uchicago, ymax = npr_dsh,
+    xmin = 0.55975,
+    xmax = 1.4425,
+    ymin = npr_dsh - npr_uchicago,
+    ymax = npr_dsh,
     fill = "#2c6d5a"
   ) +
   annotate(
@@ -1182,14 +1271,16 @@ il_hospitals_npr_summ |>
       scales::dollar(npr_uchicago, accuracy = 0.01, scale = 1 / 1e9),
       "B)"
     ),
-    hjust = 0, vjust = 0.95,
+    hjust = 0,
+    vjust = 0.95,
     fill = "transparent",
     label.color = "transparent"
   ) +
   # Rush
   annotate(
     "rect",
-    xmin = 0.55975, xmax = 1.4425,
+    xmin = 0.55975,
+    xmax = 1.4425,
     ymin = npr_dsh - npr_uchicago - npr_rush,
     ymax = npr_dsh - npr_uchicago,
     fill = "#3e987d"
@@ -1204,17 +1295,23 @@ il_hospitals_npr_summ |>
       scales::dollar(npr_rush, accuracy = 0.01, scale = 1 / 1e9),
       "B)"
     ),
-    hjust = 0, vjust = 0.95,
+    hjust = 0,
+    vjust = 0.95,
     fill = "transparent",
     label.color = "transparent"
   ) +
   geom_text(
-    aes(label = purrr::map_chr(n, scales::dollar_format(
-      accuracy = 0.01,
-      scale = 1 / 1e9,
-      prefix = "$",
-      suffix = "B"
-    ))),
+    aes(
+      label = purrr::map_chr(
+        n,
+        scales::dollar_format(
+          accuracy = 0.01,
+          scale = 1 / 1e9,
+          prefix = "$",
+          suffix = "B"
+        )
+      )
+    ),
     size = 5,
     nudge_y = 7.5e8
   ) +
@@ -1310,7 +1407,8 @@ il_hospitals_df |>
   ) +
   annotate(
     "text",
-    x = 2009.25, y = 10.5,
+    x = 2009.25,
+    y = 10.5,
     label = "ACA passed",
     color = "grey20",
     size = 4,
@@ -1553,7 +1651,8 @@ opais_ce_df |>
   ) +
   annotate(
     "text",
-    x = 2009.25, y = 1060,
+    x = 2009.25,
+    y = 1060,
     label = "ACA passed",
     color = "grey20",
     size = 4,
@@ -1656,7 +1755,8 @@ opais_cp_df |>
   ) +
   annotate(
     "text",
-    x = 2009.25, y = 1250,
+    x = 2009.25,
+    y = 1250,
     label = "ACA passed",
     color = "grey20",
     size = 4,
@@ -1669,7 +1769,8 @@ opais_cp_df |>
   ) +
   annotate(
     "text",
-    x = 2019.25, y = 3250,
+    x = 2019.25,
+    y = 3250,
     label = "Lilly creates first contract\npharmacy restriction",
     color = "darkred",
     size = 4,
@@ -1787,8 +1888,12 @@ opais_cp_df |>
     ),
     pharmacy_owner = fct_relevel(
       pharmacy_owner,
-      "CVS Health", "Walgreens", "Walmart",
-      "Jewel-Osco", "Optum Rx", "Other"
+      "CVS Health",
+      "Walgreens",
+      "Walmart",
+      "Jewel-Osco",
+      "Optum Rx",
+      "Other"
     )
   ) |>
   unnest(year) |>
@@ -1802,7 +1907,8 @@ opais_cp_df |>
   ) +
   annotate(
     "text",
-    x = 2009.25, y = 1250,
+    x = 2009.25,
+    y = 1250,
     label = "ACA passed",
     color = "grey20",
     size = 4,
@@ -1815,7 +1921,8 @@ opais_cp_df |>
   ) +
   annotate(
     "text",
-    x = 2019.25, y = 3250,
+    x = 2019.25,
+    y = 3250,
     label = "Lilly creates first contract\npharmacy restriction",
     color = "darkred",
     size = 4,
@@ -2138,7 +2245,8 @@ drug_profits_df |>
   ggplot() +
   geom_segment(
     aes(
-      x = net_outpatient_profit_lower, xend = net_outpatient_profit_upper,
+      x = net_outpatient_profit_lower,
+      xend = net_outpatient_profit_upper,
       y = plot_grp,
       color = `340b_entity_type`
     ),
@@ -2242,30 +2350,35 @@ il_hospitals_graph <- il_hospitals_df |>
     drug_profits_df |>
       select(
         provider_id,
-        net_outpatient_profit_lower, net_outpatient_profit_upper
+        net_outpatient_profit_lower,
+        net_outpatient_profit_upper
       ),
     by = "provider_id"
   ) |>
   mutate(
-    net_out_profit = (
-      net_outpatient_profit_lower + net_outpatient_profit_upper
-    ) / 2,
+    net_out_profit = (net_outpatient_profit_lower +
+      net_outpatient_profit_upper) /
+      2,
     geo_path = case_when(
       county %in% c("Cook", "DuPage", "Kane", "Lake", "McHenry", "Will") ~
         "Illinois.Chicago area",
       .default = "Illinois.Outside Chicago area"
     ),
     node = paste0(
-      geo_path, ".",
+      geo_path,
+      ".",
       str_replace_all(
         str_to_title(str_replace_all(provider_name, "[^[:alnum:]]", " ")),
-        "\\s+", "_"
+        "\\s+",
+        "_"
       )
     )
   ) |>
   select(
-    from = geo_path, to = node,
-    `340b_entity_type`, net_out_profit
+    from = geo_path,
+    to = node,
+    `340b_entity_type`,
+    net_out_profit
   ) |>
   filter(
     !is.na(net_out_profit),
@@ -2311,7 +2424,8 @@ ggraph(g, layout = "circlepack", weight = net_out_profit) +
   ) +
   annotate(
     "text",
-    x = 6.3e4, y = -3.2e4,
+    x = 6.3e4,
+    y = -3.2e4,
     label = "*Each colored circle\nrepresents one hospital",
     hjust = 1,
     lineheight = 1.1
@@ -2383,14 +2497,22 @@ ggraph(g, layout = "circlepack", weight = net_out_profit) +
 # 340B entity type
 drp_timeline_df <- il_hospitals_df |>
   select(
-    provider_id, provider_name, `340b_entity_type`, `340b_start_date`,
-    medicare_provider_id, total_beds
+    provider_id,
+    provider_name,
+    `340b_entity_type`,
+    `340b_start_date`,
+    medicare_provider_id,
+    total_beds
   ) |>
   inner_join(
     medicare_cost_df |>
       select(
-        mcr_ccn, mcr_fy_end_date, mcr_drug_cost, mcr_net_patient_revenue,
-        mcr_outpatient_drug_charged, mcr_conv_factor
+        mcr_ccn,
+        mcr_fy_end_date,
+        mcr_drug_cost,
+        mcr_net_patient_revenue,
+        mcr_outpatient_drug_charged,
+        mcr_conv_factor
       ),
     by = c("medicare_provider_id" = "mcr_ccn"),
     relationship = "many-to-many"
@@ -2409,15 +2531,17 @@ drp_timeline_df <- il_hospitals_df |>
       `340b_entity_type`,
       levels = names(entity_color_values)
     ),
-    net_outpatient_revenue_lower =
-      (mcr_outpatient_drug_charged * mcr_conv_factor),
-    net_outpatient_revenue_upper =
-      (mcr_outpatient_drug_charged * rate_to_gross_avg_wtd),
-    net_outpatient_revenue_midpoint =
-      rowMeans(pick(c(
+    net_outpatient_revenue_lower = (mcr_outpatient_drug_charged *
+      mcr_conv_factor),
+    net_outpatient_revenue_upper = (mcr_outpatient_drug_charged *
+      rate_to_gross_avg_wtd),
+    net_outpatient_revenue_midpoint = rowMeans(
+      pick(c(
         net_outpatient_revenue_lower,
         net_outpatient_revenue_upper
-      )), na.rm = TRUE),
+      )),
+      na.rm = TRUE
+    ),
     year = lubridate::year(mcr_fy_end_date)
   ) |>
   filter(
@@ -2455,14 +2579,16 @@ drp_timeline_df |>
   geom_line(
     data = drp_timeline_df_shim,
     aes(
-      x = year, y = avg_prop
+      x = year,
+      y = avg_prop
     ),
     color = "grey60",
     linewidth = 1
   ) +
   geom_line(
     aes(
-      x = year, y = avg_prop,
+      x = year,
+      y = avg_prop,
       color = `340b_entity_type`,
       group = `340b_entity_type`
     ),
@@ -2561,8 +2687,11 @@ drp_timeline_df |>
 il_hospitals_df |>
   filter(`340b_start_date` <= mcr_fy_end_date | is.na(`340b_start_date`)) |>
   select(
-    provider_id, provider_name, `340b_entity_type`,
-    medicare_provider_id, total_beds
+    provider_id,
+    provider_name,
+    `340b_entity_type`,
+    medicare_provider_id,
+    total_beds
   ) |>
   inner_join(
     ahq_stats_df |>
@@ -2591,29 +2720,40 @@ il_hospitals_df |>
   summarize(
     q10 = wtd.quantile(
       pct_charity_care,
-      weights = total_beds, probs = 0.1, na.rm = TRUE
+      weights = total_beds,
+      probs = 0.1,
+      na.rm = TRUE
     ),
     q25 = wtd.quantile(
       pct_charity_care,
-      weights = total_beds, probs = 0.25, na.rm = TRUE
+      weights = total_beds,
+      probs = 0.25,
+      na.rm = TRUE
     ),
     q50 = wtd.quantile(
       pct_charity_care,
-      weights = total_beds, probs = 0.5, na.rm = TRUE
+      weights = total_beds,
+      probs = 0.5,
+      na.rm = TRUE
     ),
     q75 = wtd.quantile(
       pct_charity_care,
-      weights = total_beds, probs = 0.75, na.rm = TRUE
+      weights = total_beds,
+      probs = 0.75,
+      na.rm = TRUE
     ),
     q90 = wtd.quantile(
       pct_charity_care,
-      weights = total_beds, probs = 0.9, na.rm = TRUE
+      weights = total_beds,
+      probs = 0.9,
+      na.rm = TRUE
     )
   ) |>
   mutate(
     is_340b = ifelse(
       `340b_entity_type` != "Not 340B",
-      "340B", "Not\n340B"
+      "340B",
+      "Not\n340B"
     ),
     is_340b = factor(is_340b, levels = c("Not\n340B", "340B")),
     `340b_entity_type` = factor(
@@ -2728,7 +2868,7 @@ il_hospitals_df |>
 #| fig-width: 9
 #| fig-height: 7
 
-obbb_stats_df <- obbb_df |> 
+obbb_stats_df <- obbb_df |>
   mutate(
     met_old = case_when(
       `340b_entity_type` %in% c("SCH", "RRC") & mcr_dsh_pct >= 0.08 ~ TRUE,
@@ -2813,18 +2953,20 @@ obbb_stats_df |>
       "Disqualified"
     )
   ) |>
-ggplot() +
+  ggplot() +
   geom_histogram(
     aes(x = mcr_dsh_pct, fill = entity_type),
     binwidth = 0.0075,
     boundary = 0.1175
   ) +
   geom_vline(
-    xintercept = 0.1175, color = "black",
+    xintercept = 0.1175,
+    color = "black",
     linetype = "dashed"
   ) +
   geom_vline(
-    xintercept = 0.08, color = "black",
+    xintercept = 0.08,
+    color = "black",
     linetype = "dashed"
   ) +
   geom_richtext(
@@ -2973,11 +3115,15 @@ obbb_stats_df |>
       pct_lost,
       breaks = c(-Inf, 0.05, 0.1, 0.2, 0.3, Inf),
       labels = c(
-        "< 5%", "5-10%", "10-20%", "20-30%", "> 30%"
+        "< 5%",
+        "5-10%",
+        "10-20%",
+        "20-30%",
+        "> 30%"
       )
     )
   ) |>
-ggplot() +
+  ggplot() +
   geom_sf(aes(fill = pct_fct), color = "grey30") +
   scale_fill_brewer(
     palette = "BuPu",
@@ -3091,7 +3237,7 @@ obbb_stats_df |>
     cnt = replace_na(cnt, 0),
     cnt_fct = replace_na(cnt_fct, "0")
   ) |>
-ggplot() +
+  ggplot() +
   geom_tile(
     aes(x = bed_fct, y = fct_rev(full_type), fill = cnt_fct),
     show.legend = TRUE
@@ -3126,9 +3272,11 @@ ggplot() +
     ),
     guide = "none"
   ) +
-  guides(fill = guide_legend(
-    override.aes = list(color = "black", linewidth = 0.3)
-  )) +
+  guides(
+    fill = guide_legend(
+      override.aes = list(color = "black", linewidth = 0.3)
+    )
+  ) +
   labs(
     title = "The OBBB's impact on 340B-qualified hospitals, by type",
     subtitle = paste0(


### PR DESCRIPTION
Posit released a [new fast, opinionated formatter](https://posit-dev.github.io/air/) for R ala Python's `ruff`. This PR just switches the config over to air (from `styler`). The big diff is just the result of formatting changes.